### PR TITLE
iOS 8 Update

### DIFF
--- a/OpenIDFA.m
+++ b/OpenIDFA.m
@@ -178,7 +178,7 @@
     //
     NSDateFormatter* dateFormatter = [ [ NSDateFormatter alloc ] init ];
     [ dateFormatter setDateFormat:@"yyMMdd" ];
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     NSDateComponents *hourShift = [[NSDateComponents alloc] init];
     [hourShift setHour:-4];
     NSDate *currentDay= [calendar dateByAddingComponents:hourShift toDate:[NSDate date] options:0];


### PR DESCRIPTION
In iOS 8, `NSGregorianCalendar` is deprecated and will be replaced with `NSCalendarIdentifierGregorian`.
